### PR TITLE
iPhoneX adaptation

### DIFF
--- a/ZYBannerView/ZYBannerView.m
+++ b/ZYBannerView/ZYBannerView.m
@@ -479,6 +479,9 @@ static NSString *banner_footer = @"banner_footer";
         _collectionView.backgroundColor = [UIColor groupTableViewBackgroundColor];
         _collectionView.delegate = self;
         _collectionView.dataSource = self;
+        if (@available(iOS 11, *)) {
+            _collectionView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+        }
         
         // 注册cell
         [_collectionView registerClass:[ZYBannerCell class] forCellWithReuseIdentifier:banner_item];


### PR DESCRIPTION
iPhoneX 适配
UICollectionView **contentInsetAdjustmentBehavior** 属性默认为
 **UIScrollViewContentInsetAdjustmentAutomatic**，会导致 banner 在贴边时，系统会自动留出空隙。
参照：[iOS Safe Area](https://medium.com/rosberryapps/ios-safe-area-ca10e919526f)